### PR TITLE
Use IPFS hash instead of file

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,19 +264,8 @@ class UPortClient {
       if (name) DDO.name = name
       if (description) DDO.description = description
       if (url) DDO.url = url
-      if (imgPath) {
-        fs.readFile(imgPath, (err, data) => {
-          if (err) reject(new Error(err))
-          this.ipfs.add(data, (err, result) => {
-            if (err) reject(new Error(err))
-            const imgHash = result
-            DDO.image = { contentUrl: `/ipfs/${imgHash}` }
-            resolve(DDO)
-          })
-        })
-      } else {
-        resolve(DDO)
-      }
+      if (imgPath) DDO.image = { contentUrl: imgPath }
+      resolve(DDO)
     })
   }
 


### PR DESCRIPTION
Modified the `appDDO` function to use an IPFS hash instead of a path to a file.