### PR TITLE
Fix object binding issue on consume method and JWT signing issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ class UPortClient {
   }
 
   initTokenSigner() {
-     const tokenSigner = new TokenSigner('ES256k', this.deviceKeys.privateKey)
+     const tokenSigner = new TokenSigner('ES256k', this.deviceKeys.privateKey.slice(2)) // Remove 0x prefix from private key
      this.signer = tokenSigner.sign.bind(tokenSigner)
   }
 

--- a/index.js
+++ b/index.js
@@ -475,6 +475,7 @@ class UPortClient {
   }
 
   consume(uri) {
+      this.consume = this.consume.bind(this); 
       if (isShareRequest(uri)) return this.shareRequestHandler(uri)
       if (isSimpleRequest(uri)) return this.simpleRequestHandler(uri)
       if (isTransactionRequest(uri)) return this.transactionRequestHandler(uri)


### PR DESCRIPTION
Adding bind method on consume method to fix issue #26
JWT signing fails: Removed 0x prefix from private key before constructing the tokenSigner class.