### PR TITLE
RejectionFlow:A fix for stopping polling on the app if user rejects request

### DIFF
--- a/index.js
+++ b/index.js
@@ -483,6 +483,20 @@ class UPortClient {
       if (isAddAttestationRequest(uri)) return this.addAttestationRequestHandler(uri)
       return Promise.reject(new Error('Invalid URI Passed'))
   }
+  rejectAttestation(uri){
+      const params = getUrlParams(uri)
+      const payload={"message":"Attestation Request Rejected"}
+      const response = this.signer(payload)
+      return this.responseHandler(response, params.callback_url,"status")
+  }
+
+  rejectRequest(uri){
+      const params = getUrlParams(uri)
+      const token = decodeToken(params.requestToken).payload
+      const payload={"message":"Request Rejected"}
+      const response = this.signer(payload)
+      return this.responseHandler(response, token.callback)
+  }
 }
 
 module.exports = { UPortClient, serialize, deserialize, networks, genKeyPair, deploy }


### PR DESCRIPTION
In the old  implementation, If the end user rejected a share/attestation request. The requesting application would still keep polling waiting for a response.

This change fixes the issue, by  calling a response handler and notifying the requesting app that a user has declined the request